### PR TITLE
Adding case to map values properly when mapping to lower case

### DIFF
--- a/spec/locales-currencies-tz.html
+++ b/spec/locales-currencies-tz.html
@@ -9,7 +9,7 @@
     <h1>Case Sensitivity and Case Mapping</h1>
 
     <p>
-      The String values used to identify locales, currencies, and time zones are interpreted in a case-insensitive manner, treating the Unicode Basic Latin characters *"A"* to *"Z"* (U+0041 to U+005A) as equivalent to the corresponding Basic Latin characters *"a"* to *"z"* (U+0061 to U+007A). No other case folding equivalences are applied. When mapping to upper case, a mapping shall be used that maps characters in the range *"a"* to *"z"* (U+0061 to U+007A) to the corresponding characters in the range *"A"* to *"Z"* (U+0041 to U+005A) and maps no other characters to the latter range.
+      The String values used to identify locales, currencies, and time zones are interpreted in a case-insensitive manner, treating the Unicode Basic Latin characters *"A"* to *"Z"* (U+0041 to U+005A) as equivalent to the corresponding Basic Latin characters *"a"* to *"z"* (U+0061 to U+007A). No other case folding equivalences are applied. When mapping to upper case, a mapping shall be used that maps characters in the range *"a"* to *"z"* (U+0061 to U+007A) to the corresponding characters in the range *"A"* to *"Z"* (U+0041 to U+005A) and maps no other characters to the latter range. When mapping to lower case, a mapping shall be used that maps characters in the range *"A"* to *"Z"* (U+0041 to U+005A) to the corresponding characters in the range *"a"* to *"z"* (U+0061 to U+007A) and maps no other characters to the latter range.
     </p>
 
     <p>


### PR DESCRIPTION
This is adding a case to consider when we map characters to lower case.

CC @littledan 